### PR TITLE
chore: hide homelab live demos while server is down

### DIFF
--- a/src/data.es.ts
+++ b/src/data.es.ts
@@ -108,7 +108,7 @@ export const PROJECTS_ES = [
     description:
       'Una app social full-stack donde viajeros solos encuentran compañía y comparten gastos de viaje. Hecha con Next.js 15 y Supabase: autenticación, dashboard personalizado, chat 1 a 1 en tiempo real, sistema de amigos, planes de viaje con filtros de descubrimiento y reseñas, con tests E2E en Playwright.',
     techs: ['Next.js 15', 'TypeScript', 'Supabase', 'Tailwind CSS', 'Playwright'],
-    live: 'https://the-orange-mate.mnr.ar',
+    live: '',
     source: 'https://github.com/TanisJam/the-orange-mate',
     tag: 'APP',
     accent: 'coral',
@@ -169,7 +169,7 @@ export const PROJECTS_ES = [
     description:
       'Dejás mensajes anónimos pineados a tu ubicación sobre un mapa de Mapbox. Las notas se agregan en celdas hexagonales H3 de Uber, mostradas como una capa de nube de palabras y burbujas flotantes arrastrables, con actualizaciones en tiempo real vía Supabase y expiración a las 48 horas.',
     techs: ['Next.js', 'TypeScript', 'Mapbox GL', 'H3', 'Supabase', 'Framer Motion'],
-    live: 'https://hecho-hex.mnr.ar',
+    live: '',
     source: 'https://github.com/TanisJam/hecho-hex',
     tag: 'APP',
     accent: 'coral',

--- a/src/data.ts
+++ b/src/data.ts
@@ -153,7 +153,7 @@ export const PROJECTS = [
     description:
       'A full-stack social app where solo travelers find companions and split travel costs. Built with Next.js 15 and Supabase, it ships authentication, a personalized dashboard, real-time 1-on-1 chat, a friends system, trip plans with discovery filters, and reviews — covered by Playwright E2E tests.',
     techs: ['Next.js 15', 'TypeScript', 'Supabase', 'Tailwind CSS', 'Playwright'],
-    live: 'https://the-orange-mate.mnr.ar',
+    live: '',
     source: 'https://github.com/TanisJam/the-orange-mate',
     tag: 'APP',
     accent: 'coral',
@@ -214,7 +214,7 @@ export const PROJECTS = [
     description:
       'Drop anonymous messages pinned to your location on a Mapbox map. Notes aggregate into Uber H3 hex cells, rendered as a word-cloud layer and floating draggable bubbles, with real-time updates via Supabase and a 48-hour expiry.',
     techs: ['Next.js', 'TypeScript', 'Mapbox GL', 'H3', 'Supabase', 'Framer Motion'],
-    live: 'https://hecho-hex.mnr.ar',
+    live: '',
     source: 'https://github.com/TanisJam/hecho-hex',
     tag: 'APP',
     accent: 'coral',


### PR DESCRIPTION
## Summary

The homelab is off this weekend (power issues), so the self-hosted demos are unreachable. This clears the `live` links for **the-orange-mate** and **hecho-hex** so the cards don't render dead "Live/Demo" buttons. Restore the URLs once the server is back.

## Changes

| File | Change |
|------|--------|
| `src/data.ts` | Emptied `live` for the-orange-mate and hecho-hex |
| `src/data.es.ts` | Emptied `live` for the-orange-mate and hecho-hex |

## Notes

- The peel `live` (npmjs.com) is untouched — it's not homelab-hosted.
- Cards hide the button when `live` is empty (`{p.live && ...}` in the projects index pages), so no broken links.